### PR TITLE
Fail strict on impossible relations

### DIFF
--- a/cql/lexer_test.go
+++ b/cql/lexer_test.go
@@ -76,9 +76,9 @@ func TestLexer(t *testing.T) {
 				{token: tokenSortby, value: "Sortby"},
 				{token: tokenSimpleString, value: "name"},
 				{token: tokenPrefixName, value: "x.relation"},
-				{token: tokenPrefixName, value: "all"},
-				{token: tokenPrefixName, value: "any"},
-				{token: tokenPrefixName, value: "adj"},
+				{token: tokenRelSym, value: "all"},
+				{token: tokenRelSym, value: "any"},
+				{token: tokenRelSym, value: "adj"},
 				{token: tokenSimpleString, value: "x\\.y"},
 				{token: tokenEos, value: ""},
 			},
@@ -96,7 +96,7 @@ func TestLexer(t *testing.T) {
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
 			var l lexer
-			l.init(testcase.input, false)
+			l.init(testcase.input)
 			last := false
 			for i := range testcase.expected {
 				if last {

--- a/cql/parser.go
+++ b/cql/parser.go
@@ -38,11 +38,12 @@ func (p *Parser) isSearchTerm() bool {
 		p.look == tokenOr ||
 		p.look == tokenNot ||
 		p.look == tokenProx ||
-		p.look == tokenSortby
+		p.look == tokenSortby ||
+		p.look == tokenRelSym
 }
 
 func (p *Parser) isRelation() bool {
-	return p.look == tokenRelOp || p.look == tokenPrefixName
+	return p.look == tokenRelOp || p.look == tokenRelSym || p.look == tokenPrefixName
 }
 
 func (p *Parser) modifiers() ([]Modifier, error) {
@@ -104,7 +105,7 @@ func (p *Parser) searchClause(ctx *context) (Clause, error) {
 
 	sb.WriteString(indexOrTerm)
 	if !p.Strict {
-		for p.look == tokenSimpleString || p.look == tokenPrefixName {
+		for p.look == tokenSimpleString || p.look == tokenPrefixName || p.look == tokenRelSym {
 			sb.WriteString(" " + p.value)
 			p.next()
 		}
@@ -194,7 +195,7 @@ func (p *Parser) sortKeys() ([]Sort, error) {
 }
 
 func (p *Parser) Parse(input string) (Query, error) {
-	p.lexer.init(input, p.Strict)
+	p.lexer.init(input)
 	p.look, p.value = p.lexer.lex()
 
 	ctx := context{index: "cql.serverChoice", relation: "="}

--- a/cql/parser_test.go
+++ b/cql/parser_test.go
@@ -554,7 +554,7 @@ func TestMultiTermAndSymRelStrict(t *testing.T) {
 	}
 	in = "a b"
 	q, err = p.Parse(in)
-	if err == nil || err.Error() != "search term expected near pos 3" {
+	if err == nil || err.Error() != "EOF expected near pos 3" {
 		t.Fatalf("expected parse error but was: %v", err)
 	}
 	out = q.String()
@@ -563,11 +563,11 @@ func TestMultiTermAndSymRelStrict(t *testing.T) {
 	}
 	in = "a b c"
 	q, err = p.Parse(in)
-	if err != nil {
-		t.Fatalf("parse error: %s", err)
+	if err == nil || err.Error() != "EOF expected near pos 4" {
+		t.Fatalf("expected parse error but was: %v", err)
 	}
 	out = q.String()
-	if in != out {
+	if in == out {
 		t.Fatalf("expected not equals: %s, %s", in, out)
 	}
 	in = "a b.c"
@@ -599,16 +599,16 @@ func TestMultiTermAndSymRelStrict(t *testing.T) {
 	}
 	in = "a b adj"
 	q, err = p.Parse(in)
-	if err != nil {
-		t.Fatalf("parse error: %s", err)
+	if err == nil || err.Error() != "EOF expected near pos 4" {
+		t.Fatalf("expected parse error but was: %v", err)
 	}
 	out = q.String()
-	if in != out {
+	if in == out {
 		t.Fatalf("expected:\n%s\nwas:\n%s", in, out)
 	}
 	in = "a b adj c"
 	q, err = p.Parse(in)
-	if err == nil || err.Error() != "search term expected near pos 9" {
+	if err == nil || err.Error() != "EOF expected near pos 4" {
 		t.Fatalf("expected parse error but was: %v", err)
 	}
 }


### PR DESCRIPTION
this ensures that strict will always produce the same parse tree as non-strict