### PR TITLE
Validate prefixes

### DIFF
--- a/cql/cql.go
+++ b/cql/cql.go
@@ -127,16 +127,22 @@ type Clause struct {
 }
 
 func (c *Clause) write(sb *strings.Builder, brackets bool) {
+	if len(c.PrefixMap) > 0 && brackets {
+		sb.WriteString("(")
+	}
 	for _, p := range c.PrefixMap {
 		p.write(sb)
 		sb.WriteString(" ")
 	}
 	if c.SearchClause != nil {
 		c.SearchClause.write(sb)
+		if len(c.PrefixMap) > 0 && brackets {
+			sb.WriteString(")")
+		}
 		return
 	}
 	if c.BoolClause != nil {
-		if brackets {
+		if len(c.PrefixMap) == 0 && brackets {
 			sb.WriteString("(")
 		}
 		c.BoolClause.write(sb)
@@ -150,6 +156,9 @@ func (c *Clause) write(sb *strings.Builder, brackets bool) {
 	sb.WriteString(string(EQ))
 	sb.WriteString(" ")
 	sb.WriteString("1")
+	if len(c.PrefixMap) > 0 && brackets {
+		sb.WriteString(")")
+	}
 }
 
 func (c *Clause) String() string {

--- a/cql/parser_test.go
+++ b/cql/parser_test.go
@@ -621,6 +621,38 @@ func TestMultiTermAndSymRelStrict(t *testing.T) {
 	if in == out {
 		t.Fatalf("expected:\n%s\nwas:\n%s", exp, out)
 	}
+	//bind prefix in main query
+	in = "> b = x a b.c d or a b.c d"
+	q, err = p.Parse(in)
+	if err != nil {
+		t.Fatalf("parse error: %s", err)
+	}
+	out = q.String()
+	exp = "> b = x a b.c d or a b.c d"
+	if exp != out {
+		t.Fatalf("expected not equals: %s, %s", exp, out)
+	}
+	//bound prefix in subquery
+	in = "a or (> b = x a b.c d)"
+	q, err = p.Parse(in)
+	if err != nil {
+		t.Fatalf("parse error: %s", err)
+	}
+	out = q.String()
+	exp = "a or (> b = x a b.c d)"
+	if exp != out {
+		t.Fatalf("expected not equals: %s, %s", exp, out)
+	}
+	//bind prefix in sub query only
+	in = "a b.c d or (> b = x a b.c d)"
+	q, err = p.Parse(in)
+	if err == nil || err.Error() != "EOF expected near pos 6" {
+		t.Fatalf("expected parse error, was: %s", err)
+	}
+	out = q.String()
+	if in == out {
+		t.Fatalf("expected not equals: %s, %s", exp, out)
+	}
 }
 
 func TestMultiTermAndSymRel(t *testing.T) {
@@ -688,6 +720,18 @@ func TestMultiTermAndSymRel(t *testing.T) {
 	if in != out {
 		t.Fatalf("expected not equals: %s, %s", in, out)
 	}
+	//bound prefix in subquery only
+	in = "a b.c d or (> b = x a b.c d)"
+	q, err = p.Parse(in)
+	if err != nil {
+		t.Fatalf("parse error: %s", err)
+	}
+	out = q.String()
+	exp = "\"a b.c d\" or (> b = x a b.c d)"
+	if exp != out {
+		t.Fatalf("expected not equals: %s, %s", exp, out)
+	}
+	//built-in relation
 	in = "a within d"
 	q, err = p.Parse(in)
 	if err != nil {


### PR DESCRIPTION
I don't feel strongly about this but this prevents mistakenly considering something to be a relation and is especially useful for the non-strict parser in cases like `1.0 1.2 1.3`.