### PR TITLE
Add WithPrefixMatch

### DIFF
--- a/pgcql/pg_field_string.go
+++ b/pgcql/pg_field_string.go
@@ -16,7 +16,7 @@ type FieldString struct {
 	enableILike     bool
 	enableExact     bool
 	enableSplit     bool
-	prefixMatch     bool
+	prefixMatchOnly bool
 	serverChoiceRel cql.Relation
 }
 
@@ -46,7 +46,7 @@ func (f *FieldString) WithLikeOps() *FieldString {
 }
 
 // WithILikeOps enables wildcard-aware case-insensitive matching and disables exact match fallback.
-// For good performance, this is typically paired with a pg_trgm GIN/GiST index.
+// This typically requires a pg_trgm (trigram) GIN/GiST index for good performance.
 func (f *FieldString) WithILikeOps() *FieldString {
 	f.enableExact = false
 	f.enableILike = true
@@ -54,18 +54,21 @@ func (f *FieldString) WithILikeOps() *FieldString {
 	return f
 }
 
-// WithPrefixMatch allows wildcard operators only at the end of a term.
+// WithPrefixMatchOnly allows wildcard operators only at the end of a term.
 // Applies to WithLikeOps/WithILikeOps matching.
-func (f *FieldString) WithPrefixMatch() *FieldString {
-	f.prefixMatch = true
+// This is useful when the underlying column is indexed with a regular btree index with text_pattern_ops/varchar_pattern_ops, which does not support leading wildcards.
+func (f *FieldString) WithPrefixMatchOnly() *FieldString {
+	f.prefixMatchOnly = true
 	return f
 }
 
+// WithExact enables exact match and using it as a fallback for WithLikeOps when no wildcard operators are used in the term.
 func (f *FieldString) WithExact() *FieldString {
 	f.enableExact = true
 	return f
 }
 
+// WithoutExact disables exact match and using it as fallback for WithLikeOps when no wildcard operators are used in the term.
 func (f *FieldString) WithoutExact() *FieldString {
 	f.enableExact = false
 	return f
@@ -76,11 +79,13 @@ func (f *FieldString) WithSplit() *FieldString {
 	return f
 }
 
+// WithServerChoiceRel configures the server choice relation
 func (f *FieldString) WithServerChoiceRel(relation cql.Relation) *FieldString {
 	f.serverChoiceRel = relation
 	return f
 }
 
+// WithAssumeTsVector assumes underlying column of type tsvector and uses it directly.
 func (f *FieldString) WithAssumeTsVector() *FieldString {
 	f.assumeTsVector = true
 	return f
@@ -200,12 +205,20 @@ func maskedSplitTsTerms(cqlTerm string, splitChars string) ([]string, error) {
 			backslash = false
 			continue
 		}
+		if wildcard {
+			if strings.ContainsRune(splitChars, c) {
+				appendTerm()
+				continue
+			}
+			if c == '\\' {
+				backslash = true
+				continue
+			}
+			return terms, fmt.Errorf("masking op * supported only at end of term")
+		}
 
 		switch c {
 		case '*':
-			if wildcard {
-				return terms, fmt.Errorf("masking op * supported only at end of term")
-			}
 			if len(pgTerm) == 0 {
 				return terms, fmt.Errorf("masking op * unsupported")
 			}
@@ -221,9 +234,6 @@ func maskedSplitTsTerms(cqlTerm string, splitChars string) ([]string, error) {
 				appendTerm()
 				continue
 			}
-			if wildcard {
-				return terms, fmt.Errorf("masking op * supported only at end of term")
-			}
 			pgTerm = append(pgTerm, c)
 		}
 	}
@@ -237,7 +247,7 @@ func maskedSplitTsTerms(cqlTerm string, splitChars string) ([]string, error) {
 	return terms, nil
 }
 
-func maskedLike(cqlTerm string, prefixMatch bool) (string, bool, error) {
+func maskedLike(cqlTerm string, prefixMatchOnly bool) (string, bool, error) {
 	var pgTerm []rune
 	ops := false
 	backslash := false
@@ -245,7 +255,7 @@ func maskedLike(cqlTerm string, prefixMatch bool) (string, bool, error) {
 
 	for _, c := range cqlTerm {
 		if backslash {
-			if prefixMatch && wildcard {
+			if prefixMatchOnly && wildcard {
 				return "", false, fmt.Errorf("masking ops * and ? supported only at end of term")
 			}
 			switch c {
@@ -258,23 +268,24 @@ func maskedLike(cqlTerm string, prefixMatch bool) (string, bool, error) {
 			}
 			backslash = false
 		} else {
+			if prefixMatchOnly && wildcard {
+				if c == '\\' {
+					backslash = true
+					continue
+				}
+				return "", false, fmt.Errorf("masking ops * and ? supported only at end of term")
+			}
 			switch c {
 			case '*':
-				if prefixMatch && wildcard {
-					return "", false, fmt.Errorf("masking ops * and ? supported only at end of term")
-				}
 				pgTerm = append(pgTerm, '%')
 				ops = true
-				if prefixMatch {
+				if prefixMatchOnly {
 					wildcard = true
 				}
 			case '?':
-				if prefixMatch && wildcard {
-					return "", false, fmt.Errorf("masking ops * and ? supported only at end of term")
-				}
 				pgTerm = append(pgTerm, '_')
 				ops = true
-				if prefixMatch {
+				if prefixMatchOnly {
 					wildcard = true
 				}
 			case '^':
@@ -284,9 +295,6 @@ func maskedLike(cqlTerm string, prefixMatch bool) (string, bool, error) {
 			case '%', '_':
 				pgTerm = append(pgTerm, '\\', c)
 			default:
-				if prefixMatch && wildcard {
-					return "", false, fmt.Errorf("masking ops * and ? supported only at end of term")
-				}
 				pgTerm = append(pgTerm, c)
 			}
 		}
@@ -362,7 +370,7 @@ func (f *FieldString) Generate(sc cql.SearchClause, queryArgumentIndex int) (str
 		}
 	}
 	if (f.enableLike || f.enableILike) && (sc.Relation == cql.EQ || sc.Relation == cql.EXACT || sc.Relation == cql.NE) {
-		pgTerm, ops, err := maskedLike(sc.Term, f.prefixMatch)
+		pgTerm, ops, err := maskedLike(sc.Term, f.prefixMatchOnly)
 		if err != nil {
 			return "", nil, err
 		}

--- a/pgcql/pg_field_string.go
+++ b/pgcql/pg_field_string.go
@@ -205,11 +205,11 @@ func maskedSplitTsTerms(cqlTerm string, splitChars string) ([]string, error) {
 			backslash = false
 			continue
 		}
+		if strings.ContainsRune(splitChars, c) {
+			appendTerm()
+			continue
+		}
 		if wildcard {
-			if strings.ContainsRune(splitChars, c) {
-				appendTerm()
-				continue
-			}
 			if c == '\\' {
 				backslash = true
 				continue
@@ -230,10 +230,6 @@ func maskedSplitTsTerms(cqlTerm string, splitChars string) ([]string, error) {
 		case '\\':
 			backslash = true
 		default:
-			if strings.ContainsRune(splitChars, c) {
-				appendTerm()
-				continue
-			}
 			pgTerm = append(pgTerm, c)
 		}
 	}

--- a/pgcql/pg_field_string.go
+++ b/pgcql/pg_field_string.go
@@ -16,6 +16,7 @@ type FieldString struct {
 	enableILike     bool
 	enableExact     bool
 	enableSplit     bool
+	prefixMatch     bool
 	serverChoiceRel cql.Relation
 }
 
@@ -50,6 +51,13 @@ func (f *FieldString) WithILikeOps() *FieldString {
 	f.enableExact = false
 	f.enableILike = true
 	f.enableLike = false
+	return f
+}
+
+// WithPrefixMatch allows wildcard operators only at the end of a term.
+// Applies to WithLikeOps/WithILikeOps matching.
+func (f *FieldString) WithPrefixMatch() *FieldString {
+	f.prefixMatch = true
 	return f
 }
 
@@ -229,13 +237,17 @@ func maskedSplitTsTerms(cqlTerm string, splitChars string) ([]string, error) {
 	return terms, nil
 }
 
-func maskedLike(cqlTerm string) (string, bool, error) {
+func maskedLike(cqlTerm string, prefixMatch bool) (string, bool, error) {
 	var pgTerm []rune
 	ops := false
 	backslash := false
+	wildcard := false
 
 	for _, c := range cqlTerm {
 		if backslash {
+			if prefixMatch && wildcard {
+				return "", false, fmt.Errorf("masking ops * and ? supported only at end of term")
+			}
 			switch c {
 			case '*', '?', '^', '"':
 				pgTerm = append(pgTerm, c)
@@ -248,11 +260,23 @@ func maskedLike(cqlTerm string) (string, bool, error) {
 		} else {
 			switch c {
 			case '*':
+				if prefixMatch && wildcard {
+					return "", false, fmt.Errorf("masking ops * and ? supported only at end of term")
+				}
 				pgTerm = append(pgTerm, '%')
 				ops = true
+				if prefixMatch {
+					wildcard = true
+				}
 			case '?':
+				if prefixMatch && wildcard {
+					return "", false, fmt.Errorf("masking ops * and ? supported only at end of term")
+				}
 				pgTerm = append(pgTerm, '_')
 				ops = true
+				if prefixMatch {
+					wildcard = true
+				}
 			case '^':
 				return "", false, fmt.Errorf("anchor op ^ unsupported")
 			case '\\':
@@ -260,6 +284,9 @@ func maskedLike(cqlTerm string) (string, bool, error) {
 			case '%', '_':
 				pgTerm = append(pgTerm, '\\', c)
 			default:
+				if prefixMatch && wildcard {
+					return "", false, fmt.Errorf("masking ops * and ? supported only at end of term")
+				}
 				pgTerm = append(pgTerm, c)
 			}
 		}
@@ -335,7 +362,7 @@ func (f *FieldString) Generate(sc cql.SearchClause, queryArgumentIndex int) (str
 		}
 	}
 	if (f.enableLike || f.enableILike) && (sc.Relation == cql.EQ || sc.Relation == cql.EXACT || sc.Relation == cql.NE) {
-		pgTerm, ops, err := maskedLike(sc.Term)
+		pgTerm, ops, err := maskedLike(sc.Term, f.prefixMatch)
 		if err != nil {
 			return "", nil, err
 		}

--- a/pgcql/pgcql_test.go
+++ b/pgcql/pgcql_test.go
@@ -59,6 +59,7 @@ func TestParsing(t *testing.T) {
 
 	author := NewFieldString().WithLikeOps().WithColumn("Author")
 	authorLikeOnly := NewFieldString().WithLikeOps().WithoutExact().WithColumn("Author")
+	authorPrefix := NewFieldString().WithLikeOps().WithPrefixMatch().WithColumn("Author")
 	authorLower := NewFieldString().WithLikeOps().WithLower().WithColumn("Author")
 	authori := NewFieldString().WithILikeOps().WithColumn("Author")
 	authoriLower := NewFieldString().WithILikeOps().WithLower().WithColumn("Author")
@@ -80,6 +81,7 @@ func TestParsing(t *testing.T) {
 	def.AddField("title", title).
 		AddField("author", author).
 		AddField("authorLikeOnly", authorLikeOnly).
+		AddField("authorPrefix", authorPrefix).
 		AddField("authorLower", authorLower).
 		AddField("titleLower", titleLower).
 		AddField("authori", authori).
@@ -135,6 +137,12 @@ func TestParsing(t *testing.T) {
 		{"authorLikeOnly <> \"test*\"", "Author NOT LIKE $1", []any{"test%"}},
 		{"authorLikeOnly = Test", "Author LIKE $1", []any{"Test"}},
 		{"authorLikeOnly <> Test", "Author NOT LIKE $1", []any{"Test"}},
+		{"authorPrefix = \"test*\"", "Author LIKE $1", []any{"test%"}},
+		{"authorPrefix = \"te?\"", "Author LIKE $1", []any{"te_"}},
+		{"authorPrefix = \"*test\"", "error: masking ops * and ? supported only at end of term", nil},
+		{"authorPrefix = \"te*st\"", "error: masking ops * and ? supported only at end of term", nil},
+		{"authorPrefix = \"te?s\"", "error: masking ops * and ? supported only at end of term", nil},
+		{"authorPrefix = \"te\\*st\"", "Author = $1", []any{"te*st"}},
 		{"authorLower = \"test*\"", "lower(Author) LIKE lower($1)", []any{"test%"}},
 		{"authorLower <> \"test*\"", "lower(Author) NOT LIKE lower($1)", []any{"test%"}},
 		{"authorLower = Test", "lower(Author) = lower($1)", []any{"Test"}},

--- a/pgcql/pgcql_test.go
+++ b/pgcql/pgcql_test.go
@@ -50,6 +50,16 @@ func TestOrderByFields(t *testing.T) {
 	}
 }
 
+func TestMaskedLikePrefixTrailingBackslash(t *testing.T) {
+	_, _, err := maskedLike("te*\\", true)
+	assert.EqualError(t, err, "a CQL string must not end with a masking backslash")
+}
+
+func TestMaskedSplitTsTermsTrailingBackslashAfterWildcard(t *testing.T) {
+	_, err := maskedSplitTsTerms("a*\\", " ")
+	assert.EqualError(t, err, "a CQL string must not end with a masking backslash")
+}
+
 func TestParsing(t *testing.T) {
 	def := NewPgDefinition()
 	title := &FieldString{}
@@ -59,7 +69,7 @@ func TestParsing(t *testing.T) {
 
 	author := NewFieldString().WithLikeOps().WithColumn("Author")
 	authorLikeOnly := NewFieldString().WithLikeOps().WithoutExact().WithColumn("Author")
-	authorPrefix := NewFieldString().WithLikeOps().WithPrefixMatch().WithColumn("Author")
+	authorPrefix := NewFieldString().WithLikeOps().WithPrefixMatchOnly().WithColumn("Author")
 	authorLower := NewFieldString().WithLikeOps().WithLower().WithColumn("Author")
 	authori := NewFieldString().WithILikeOps().WithColumn("Author")
 	authoriLower := NewFieldString().WithILikeOps().WithLower().WithColumn("Author")
@@ -142,6 +152,9 @@ func TestParsing(t *testing.T) {
 		{"authorPrefix = \"*test\"", "error: masking ops * and ? supported only at end of term", nil},
 		{"authorPrefix = \"te*st\"", "error: masking ops * and ? supported only at end of term", nil},
 		{"authorPrefix = \"te?s\"", "error: masking ops * and ? supported only at end of term", nil},
+		{"authorPrefix = \"te*\\\\\"", "error: masking ops * and ? supported only at end of term", nil},
+		{"authorPrefix = \"te*\\\\*\"", "error: masking ops * and ? supported only at end of term", nil},
+		{"authorPrefix = \"te*\\\\?\"", "error: masking ops * and ? supported only at end of term", nil},
 		{"authorPrefix = \"te\\*st\"", "Author = $1", []any{"te*st"}},
 		{"authorLower = \"test*\"", "lower(Author) LIKE lower($1)", []any{"test%"}},
 		{"authorLower <> \"test*\"", "lower(Author) NOT LIKE lower($1)", []any{"test%"}},
@@ -183,6 +196,7 @@ func TestParsing(t *testing.T) {
 		{"full = abc", "to_tsvector('english', full) @@ to_tsquery('english', $1)", []any{"'abc'"}},
 		{"full = \"abc\"", "to_tsvector('english', full) @@ to_tsquery('english', $1)", []any{"'abc'"}},
 		{"full = \"abc \"", "to_tsvector('english', full) @@ to_tsquery('english', $1)", []any{"'abc'"}},
+		{"full = \"a*\\\\\"", "error: masking op * supported only at end of term", nil},
 		{"full adj \"a b\"", "to_tsvector('english', full) @@ to_tsquery('english', $1)", []any{"'a'<->'b'"}},
 		{"full all \"a b\"", "to_tsvector('english', full) @@ to_tsquery('english', $1)", []any{"'a'&'b'"}},
 		{"full = \"a b\"", "to_tsvector('english', full) @@ to_tsquery('english', $1)", []any{"'a'&'b'"}},


### PR DESCRIPTION
constraint-only, infix wildcards cannot use regular btrees